### PR TITLE
Modify test to agree with RetDec using patched Capstone 4.0.2

### DIFF
--- a/bugs/archive-string-detection/test.py
+++ b/bugs/archive-string-detection/test.py
@@ -59,7 +59,7 @@ class TestPowerPCElf(Test):
     )
 
     def test_relocations_applied(self):
-        assert self.out_dsm.contains('0xfc:\s*30 60 01 6c\s*addic r3, r0, 0x16c')
-        assert self.out_dsm.contains('0x108:\s*33 a0 01 7c\s*addic r29, r0, 0x17c')
+        assert self.out_dsm.contains('0xfc:\s*30 60 01 6c\s*addic r3, r0, 364')
+        assert self.out_dsm.contains('0x108:\s*33 a0 01 7c\s*addic r29, r0, 380')
         assert self.out_dsm.contains('0x110:\s*4b ff fe f1\s*bl 0x0 <foo>')
         assert self.out_dsm.contains('0x11c:\s*4b ff ff 6d\s*bl 0x88 <bar>')


### PR DESCRIPTION
Capstone version 4.0.2 has a bug when disassembling a powerpc instruction
with a signed 16-bit immediate.
See https://github.com/capstone-engine/capstone/issues/1746 and
https://github.com/capstone-engine/capstone/issues/1746#issuecomment-1186559582.

RetDec PR https://github.com/avast/retdec/pull/1086 moved RetDec up to
version 4.0.2 of Capstone, but adds a patch to fix this bug. The
fix includes not printing the immediates in hex (a later version
of Capstone that fixes this problem no long prints the immediates in hex).
This change fixes a test to agree with the new behavior.